### PR TITLE
:art: Update the titles and only update from main branch

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -32,7 +32,7 @@ jobs:
           sphinx-build --nitpicky --fail-on-warning --keep-going -b html .  _build
 
       - name: Save to gh-pages
-        # # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,9 @@ intersphinx_mapping = {
 # html_title = ""
 html_theme = "sphinx_book_theme"
 # html_logo = "_static/logo-wide.svg"
-html_logo = 'https://images.seeklogo.com/logo-png/44/2/streamlit-logo-png_seeklogo-441815.png'
+html_logo = (
+    "https://images.seeklogo.com/logo-png/44/2/streamlit-logo-png_seeklogo-441815.png"
+)
 # html_favicon = "_static/logo-square.svg"
 html_theme_options = {
     "github_url": "https://github.com/Multiomics-Analytics-Group/streamlit_demo",
@@ -118,7 +120,7 @@ html_theme_options = {
     "logo": {
         "link": "https://streamlit.io/",
         "text": "Streamlit Demo",
-    }
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ from importlib import metadata
 
 # -- Project information -----------------------------------------------------
 
-project = "python_package"
+project = "Streamlit Demo"
 copyright = "2025, Henry Webel"
 author = "Henry Webel"
 PACKAGE_VERSION = metadata.version("python_package")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,7 @@ intersphinx_mapping = {
 # html_title = ""
 html_theme = "sphinx_book_theme"
 # html_logo = "_static/logo-wide.svg"
+html_logo = 'https://images.seeklogo.com/logo-png/44/2/streamlit-logo-png_seeklogo-441815.png'
 # html_favicon = "_static/logo-square.svg"
 html_theme_options = {
     "github_url": "https://github.com/Multiomics-Analytics-Group/streamlit_demo",
@@ -113,6 +114,11 @@ html_theme_options = {
         #     "notebook_interface": "jupyterlab",
     },
     "navigation_with_keys": False,
+    # https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/branding.html
+    "logo": {
+        "link": "https://streamlit.io/",
+        "text": "Streamlit Demo",
+    }
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-# Python Package Documentation
-
 ```{include} ../README.md
 :start-line: 0
 :end-line: 9

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,3 @@ reference/python_package
 README
 developing
 ```
-
-## Indices and tables
-
-- [Index](genindex)
-- [Module Index](modindex)
-- [Search](search)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 authors = [{ name = "Henry Webel", email = "heweb@dtu.dk" }]
 description = "A small example package"
-name = "python_package"
+name = "Streamlit-Demo"
 # This means: Load the version from the package itself.
 # See the section below: [tools.setuptools.dynamic]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 authors = [{ name = "Henry Webel", email = "heweb@dtu.dk" }]
 description = "A small example package"
-name = "Streamlit-Demo"
+name = "python_package"
 # This means: Load the version from the package itself.
 # See the section below: [tools.setuptools.dynamic]
 dynamic = [


### PR DESCRIPTION
This pull request updates the documentation to reflect the new project branding as "Streamlit Demo" and makes several improvements to the Sphinx configuration and website build process. The changes include updating the project name, adding a new logo, improving branding links, and ensuring the website is only deployed from the main branch.

**Branding and configuration updates:**

* Changed the project name in `docs/conf.py` from `"python_package"` to `"Streamlit Demo"` to reflect the new branding.
* Added a new logo to the Sphinx documentation by setting `html_logo` to a Streamlit logo URL in `docs/conf.py`.
* Enhanced Sphinx theme branding by adding a logo link and text that point to the Streamlit website in `docs/conf.py`.

**Documentation cleanup:**

* Removed the old title and indices/tables sections from `docs/index.md` to streamline the documentation homepage. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L1-L2) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L54-L59)

**Build process improvement:**

* Enabled deployment to GitHub Pages only when building from the `main` branch in `.github/workflows/build_website.yml`.